### PR TITLE
Max time returns events before and after and API key

### DIFF
--- a/preferences.json
+++ b/preferences.json
@@ -9,6 +9,12 @@
 		"opencagegeocodingAPIKey": "2642206c773e4b06aedabd0a0e876a2f",
 		"openrouteserviceAPIKey": "5b3ce3597851110001cf62488ef50484ef524d228826ecc7b35f5df1"
 	},
+        "cal": {
+                "caldav_url": "https://p36-caldav.icloud.com/17167915149/calendars",
+                "calendar": "Work",
+                "username": "buerro@icloud.com",
+                "password": "gxuu-sgbx-jovu-qhao"
+        },
 	"cooking": {
 		"diet": "omnivore",
 		"intolerances": "Shellfish",
@@ -20,7 +26,7 @@
 	},
 	"work_session": {
 		"min_work_period_minutes": 30,
-        "be_minutes_early": 10
+                "be_minutes_early": 10
 	},
 	"transport": {
 		"minTemp": 10,

--- a/services/cal/cal_service.py
+++ b/services/cal/cal_service.py
@@ -113,23 +113,23 @@ class CalService:
         events = self.get_events_between(start, end)
 
         if not events:
-            return end - start, None, None
+            return end - start, start, end
 
         max_delta = events[0].get_start() - start
-        event_before = None
-        event_after = events[0]
+        before = start
+        after = events[0].get_start()
 
         time_until_end = end - events[-1].get_end()
         if time_until_end > max_delta:
             max_delta = time_until_end
-            event_before = events[-1]
-            event_after = None
+            before = events[-1].get_end()
+            after = end
 
         for previous, current in zip(events, events[1:]):
             delta = current.get_start() - previous.get_end()
             if delta > max_delta:
                 max_delta = delta
-                event_before = previous
-                event_after = current
+                before = previous.get_end()
+                after = current.get_start()
 
-        return max_delta, event_before, event_after
+        return max_delta, before, after

--- a/services/cal/cal_service.py
+++ b/services/cal/cal_service.py
@@ -112,16 +112,23 @@ class CalService:
         events = self.get_events_between(start, end)
 
         if not events:
-            return end - start
+            return end - start, None, None
 
-        time_until_first = events[0].get_start() - start
+        max_delta = events[0].get_start() - start
+        event_before = None
+        event_after = events[0]
+
         time_until_end = end - events[-1].get_end()
+        if time_until_end > max_delta:
+            max_delta = time_until_end
+            event_before = events[-1]
+            event_after = None
 
-        max_delta = max((time_until_first, time_until_end))
         for previous, current in zip(events, events[1:]):
             delta = current.get_start() - previous.get_end()
             if delta > max_delta:
                 max_delta = delta
+                event_before = previous
+                event_after = current
 
-
-        return max_delta
+        return max_delta, event_before, event_after

--- a/services/cal/test/test_service.py
+++ b/services/cal/test/test_service.py
@@ -118,8 +118,8 @@ class TestCalService(unittest.TestCase):
             max_time, before, after = self.cal_service.get_max_available_time_between(
                 start_time, end_time)
             self.assertEqual(max_time, end_time - start_time)
-            self.assertIsNone(before)
-            self.assertIsNone(after)
+            self.assertEqual(before, start_time)
+            self.assertEqual(after, end_time)
 
         event1 = Event()
         summary = ''.join(random.choices(string.ascii_uppercase + string.digits,k=6))
@@ -141,8 +141,8 @@ class TestCalService(unittest.TestCase):
             max_time, before, after = self.cal_service.get_max_available_time_between(
                 start_time, end_time)
             self.assertGreater(max_time, timedelta(minutes=30))
-            self.assertEqual(_chop_dt(before.get_start()), _chop_dt(event2.get_start()))
-            self.assertIsNone(after)
+            self.assertEqual(_chop_dt(before), _chop_dt(event2.get_end()))
+            self.assertEqual(after, end_time)
 
         with self.subTest(msg="rest of the day with events of shorter delta"):
             # each of which are 15 minutes apart
@@ -160,5 +160,5 @@ class TestCalService(unittest.TestCase):
             max_time, before, after = self.cal_service.get_max_available_time_between(
                 start_time, end_time)
             self.assertEqual(timedelta(minutes=30), max_time)
-            self.assertEqual(_chop_dt(before.get_start()), _chop_dt(event1.get_start()))
-            self.assertEqual(_chop_dt(after.get_start()), _chop_dt(event2.get_start()))
+            self.assertEqual(_chop_dt(before), _chop_dt(event1.get_end()))
+            self.assertEqual(_chop_dt(after), _chop_dt(event2.get_start()))

--- a/services/cal/test/test_service.py
+++ b/services/cal/test/test_service.py
@@ -108,6 +108,9 @@ class TestCalService(unittest.TestCase):
         self.assertEqual(next_events[1]['summary'], summary2)
 
     def test_get_max_available_time_between(self):
+        def _chop_dt(date:dt):
+            return date.replace(microsecond=0)
+
         start_time = self.now()
         end_time = self.now() + timedelta(hours=4)
 
@@ -138,7 +141,7 @@ class TestCalService(unittest.TestCase):
             max_time, before, after = self.cal_service.get_max_available_time_between(
                 start_time, end_time)
             self.assertGreater(max_time, timedelta(minutes=30))
-            self.assertEqual(before.get_start(), event2.get_start())
+            self.assertEqual(_chop_dt(before.get_start()), _chop_dt(event2.get_start()))
             self.assertIsNone(after)
 
         with self.subTest(msg="rest of the day with events of shorter delta"):
@@ -157,5 +160,5 @@ class TestCalService(unittest.TestCase):
             max_time, before, after = self.cal_service.get_max_available_time_between(
                 start_time, end_time)
             self.assertEqual(timedelta(minutes=30), max_time)
-            self.assertEqual(before.get_start(), event1.get_start())
-            self.assertEqual(after.get_start(), event2.get_start())
+            self.assertEqual(_chop_dt(before.get_start()), _chop_dt(event1.get_start()))
+            self.assertEqual(_chop_dt(after.get_start()), _chop_dt(event2.get_start()))


### PR DESCRIPTION
@timozuther 
@Ovakefali13 

`get_max_available_time_between(start, end)` now also returns end  `before` and `after` as second and third in tuple. 

`before` equals the `start` argument if the max time is start until first event or until `end`
`after` equals the `end` argument analogously

Usage:
```py
from datetime import datetime as dt, timedelta
import pytz

start = dt.now(pytz.utc).replace(hours=11, minutes=0, seconds=0)
end = start + timedelta(hours=3)
max_time, start, end = get_max_available_time_between(start, end)

min_time = timedelta(minutes=90)
if max_time < min_time:
     raise Exception("not enough time")

lunch = Event()
lunch.set_title('Lunch')
lunch.set_location('Onkel Otto')
lunch.set_start(before + timedelta(minutes=15)
lunch.set_end(lunch.get_start() + timedelta(minutes=60))
self.cal_service.add_event(lunch)
```

