### PR TITLE
Instantiate default remote in constructor body instead of as default arg

### DIFF
--- a/services/cal/cal_service.py
+++ b/services/cal/cal_service.py
@@ -99,8 +99,11 @@ class iCloudCaldavRemote(CalRemote):
 @Singleton
 class CalService:
 
-    def __init__(self, remote:CalRemote = iCloudCaldavRemote.instance()):
-        self.remote = remote
+    def __init__(self, remote:CalRemote=None):
+        if remote:
+            self.remote = remote
+        else:
+            self.remote = iCloudCaldavRemote.instance()
 
     def set_remote(self, remote:CalRemote):
         if not issubclass(remote, CalRemote):

--- a/services/github/github_service.py
+++ b/services/github/github_service.py
@@ -33,9 +33,13 @@ class GithubService:
     remote = None
     pref = None
 
-    def __init__(self, remote:GithubRemote = GithubRealRemote.instance(), fallback:GithubRemote = None):
+    def __init__(self, remote:GithubRemote=None):
+        if remote:
+            self.remote = remote
+        else:
+            self.remote = GithubRealRemote.instance()
+
         self.pref = PrefService().get_preferences('github')
-        self.remote = remote
 
     def set_remote(self,remote):
         self.remote = remote

--- a/services/maps/geocoding_service.py
+++ b/services/maps/geocoding_service.py
@@ -38,8 +38,11 @@ class GeocodingJSONRemote(GeocodingRemote):
 @Singleton
 class GeocodingService:
 
-    def __init__(self, remote:GeocodingRemote=GeocodingJSONRemote.instance()):
-        self.remote = remote
+    def __init__(self, remote:GeocodingRemote=None):
+        if remote:
+            self.remote = remote
+        else:
+            self.remote = GeocodingJSONRemote.instance()
 
     def get_coords_from_address(self, address:str):
         # filter blank strings

--- a/services/maps/map_service.py
+++ b/services/maps/map_service.py
@@ -57,8 +57,11 @@ class MapJSONRemote(MapRemote):
 @Singleton
 class MapService:
 
-    def __init__(self, remote:MapRemote=MapJSONRemote.instance()):
-        self.remote = remote
+    def __init__(self, remote:MapRemote=None):
+        if remote:
+            self.remote = remote
+        else:
+            self.remote = MapJSONRemote.instance()
 
 
     def get_route_summary(self, start:tuple, dest:tuple, travel_mode:str=None):

--- a/services/music/music_service.py
+++ b/services/music/music_service.py
@@ -169,8 +169,11 @@ class SpotifyRemote(MusicRemote):
 
 @Singleton
 class MusicService:
-    def __init__(self, remote=SpotifyRemote.instance()):
-        self.remote = remote
+    def __init__(self, remote=None):
+        if remote:
+            self.remote = remote
+        else:
+            self.remote = SpotifyRemote.instance()
 
     def set_remote(self, remote:MusicRemote):
         self.remote = remote

--- a/services/preferences/pref_service.py
+++ b/services/preferences/pref_service.py
@@ -22,8 +22,11 @@ class PrefJSONRemote(PrefRemote):
 class PrefService:
     remote = None
 
-    def __init__(self, remote=PrefJSONRemote()):
-        self.remote = remote
+    def __init__(self, remote=None):
+        if remote:
+            self.remote = remote
+        else:
+            self.remote = PrefJSONRemote()
 
     def get_preferences(self, key):
         preferences_json = self.remote.load_file()

--- a/services/spoonacular/spoonacular_service.py
+++ b/services/spoonacular/spoonacular_service.py
@@ -38,14 +38,14 @@ class SpoonacularJSONRemote(SpoonacularRemote):
             print(request_string)
         response_json = response_string.json()
         return(response_json['results'][0]['id'])
-    
+
     def get_search_options(self, ingredient):
         search_options = 'includeIngredients=' + ingredient
         search_options += '&diet=' + self.diet
         search_options += '&maxReadyTime=' + str(self.maxCookingTime)
         search_options += '&apiKey=' + self.api_token
         return search_options
-    
+
     def search_recipe_by_id(self, id):
         request_string = self.base_url + str(id) +'/information?apiKey=' + self.api_token
         response_string = requests.get(request_string)
@@ -62,9 +62,11 @@ class SpoonacularService:
     ingredient = ''
     recipe = []
 
-    def __init__(self,
-        remote:SpoonacularRemote = SpoonacularJSONRemote.instance()):
-        self.remote = remote
+    def __init__(self, remote:SpoonacularRemote=None):
+        if remote:
+            self.remote = remote
+        else:
+            self.remote = SpoonacularJSONRemote.instance()
 
     def set_remote(self, remote):
         self.remote = remote

--- a/services/todoAPI/todoist_service.py
+++ b/services/todoAPI/todoist_service.py
@@ -57,8 +57,11 @@ class TodoistJSONRemote(TodoistRemote):
 class TodoistService:
     remote = None
 
-    def __init__(self, remote:TodoistRemote = TodoistJSONRemote.instance()):
-        self.remote = remote
+    def __init__(self, remote:TodoistRemote=None):
+        if remote:
+            self.remote = remote
+        else:
+            self.remote = TodoistJSONRemote.instance()
 
     def set_remote(self, remote:TodoistJSONRemote):
         self.remote = remote

--- a/services/vvs/vvs_service.py
+++ b/services/vvs/vvs_service.py
@@ -63,8 +63,11 @@ class VVSEfaJSONRemote(VVSRemote):
 @Singleton
 class VVSService:
 
-    def __init__(self, remote:VVSRemote = VVSEfaJSONRemote.instance()):
-        self.remote = remote
+    def __init__(self, remote:VVSRemote=None):
+        if remote:
+            self.remote = remote
+        else:
+            self.remote =  VVSEfaJSONRemote.instance()
 
     def set_remote(self, remote:VVSRemote):
         self.remote = remote

--- a/services/weatherAPI/weather_service.py
+++ b/services/weatherAPI/weather_service.py
@@ -89,8 +89,12 @@ class WeatherAdapter:
     MIN_TEMP = 10.0 #°C
     MAX_WIND = 20.0 #km/h
 
-    def __init__(self, remote:WeatherAdapterModule = WeatherAdapterRemote.instance()):
-        self.remote = remote
+    def __init__(self, remote:WeatherAdapterModule=None):
+        if remote:
+            self.remote = remote
+        else:
+            self.remote =  WeatherAdapterRemote.instance()
+
         self.pref = PrefService()
         #get_preferences('weather')
         self.MIN_TEMP = self.pref.get_specific_pref('min_temp')

--- a/services/yelp/yelp_service.py
+++ b/services/yelp/yelp_service.py
@@ -45,8 +45,11 @@ class YelpService:
     remote = None
     pref = None
 
-    def __init__(self, remote:YelpServiceModule = YelpServiceRemote.instance()):
-        self.remote = remote
+    def __init__(self, remote:YelpServiceModule=None):
+        if remote:
+            self.remote = remote
+        else:
+            self.remote = YelpServiceRemote.instance()
         self.pref = PrefService()
 
     def set_remote(self, remote):


### PR DESCRIPTION
I realized that it takes long to import all modules. This is because services are instantiate their default remotes in their constructor arguments which is executed upon `import`, not when the constructor is actually called.

This change makes tests significantly faster.