### PR TITLE
Do not require a .env, and actually mock weather adapter

### DIFF
--- a/services/cal/cal_service.py
+++ b/services/cal/cal_service.py
@@ -49,9 +49,9 @@ class iCloudCaldavRemote(CalRemote):
                     return cal
 
         client = caldav.DAVClient(
-            os.environ["CALDAV_URL"],
-            username=os.environ["CALDAV_USERNAME"],
-            password=os.environ["CALDAV_PASSWORD"],
+            os.getenv("CALDAV_URL"),
+            username=os.getenv("CALDAV_USERNAME"),
+            password=os.getenv("CALDAV_PASSWORD"),
         )
 
         if not calendar_name:

--- a/services/cal/test/test_service.py
+++ b/services/cal/test/test_service.py
@@ -45,7 +45,7 @@ class TestCalService(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         if "DONOTMOCK" in os.environ:
-            purgable_calendar = os.environ["CALDAV_PURGABLE_CALENDAR"]
+            purgable_calendar = os.getenv("CALDAV_PURGABLE_CALENDAR")
             self.cal_service = CalService.instance(
                 iCloudCaldavRemote.instance(purgable_calendar)
             )

--- a/services/github/github_service.py
+++ b/services/github/github_service.py
@@ -53,8 +53,4 @@ class GithubService:
         return self.remote.get_notifications()
 
     def connect(self):
-        try:
-            self.remote.connect(os.environ["GITHUB_API_KEY"])
-        except:
-            if fallback != None:
-                self.remote = fallback
+        self.remote.connect(os.getenv("GITHUB_API_KEY"))

--- a/services/maps/geocoding_service.py
+++ b/services/maps/geocoding_service.py
@@ -25,7 +25,7 @@ class GeocodingJSONRemote(GeocodingRemote):
     def __init__(self):
         pref_service = PrefService(PrefJSONRemote())
         prefs = pref_service.get_preferences("transport")
-        self.geocoder = OpenCageGeocode(os.environ["OPENCAGEGEOCODING_API_KEY"])
+        self.geocoder = OpenCageGeocode(os.getenv("OPENCAGEGEOCODING_API_KEY"))
 
     # Street, City, Country
     def get_information_from_address(self, address: str):

--- a/services/maps/map_service.py
+++ b/services/maps/map_service.py
@@ -23,7 +23,7 @@ class MapJSONRemote(MapRemote):
             "start": None,
             "end": None,
             "profile": None,
-            "api_key": os.environ["OPENROUTESERVICE_API_KEY"],
+            "api_key": os.getenv("OPENROUTESERVICE_API_KEY"),
         }
 
     def __set_route__(self, start: tuple, dest: tuple):

--- a/services/music/music_service.py
+++ b/services/music/music_service.py
@@ -78,8 +78,8 @@ class SpotifyRemote(MusicRemote):
             )
             return {"Authorization": "Basic %s" % auth_header.decode("ascii")}
 
-        client_id = os.environ['SPOTIFY_CLIENT_ID']
-        client_secret = os.environ['SPOTIFY_CLIENT_SECRET']
+        client_id = os.getenv('SPOTIFY_CLIENT_ID')
+        client_secret = os.getenv('SPOTIFY_CLIENT_SECRET')
 
         headers = _make_authorization_headers(client_id, client_secret)
 
@@ -105,7 +105,7 @@ class SpotifyRemote(MusicRemote):
 
     def get_user_playlists(self):
 
-        username = os.environ['SPOTIFY_USERNAME']
+        username = os.getenv('SPOTIFY_USERNAME')
         endpoint = self.api_base + f'/users/{username}/playlists'
 
         def _request_user_playlist(limit, offset):

--- a/services/spoonacular/spoonacular_service.py
+++ b/services/spoonacular/spoonacular_service.py
@@ -28,7 +28,7 @@ class SpoonacularJSONRemote(SpoonacularRemote):
     def __init__(self):
         pref_json = self.pref_service.get_preferences("cooking")
 
-        self.api_token = os.environ["SPOONACULAR_API_KEY"]
+        self.api_token = os.getenv("SPOONACULAR_API_KEY")
         self.diet = pref_json["diet"]
         self.maxCookingTime = pref_json["maxCookingTime"]
 

--- a/services/todoAPI/todoist_service.py
+++ b/services/todoAPI/todoist_service.py
@@ -33,7 +33,7 @@ class TodoistJSONRemote(TodoistRemote):
 
     def __init__(self):
         pref_json = self.pref_service.get_preferences("cooking")
-        self.api_token = os.environ["TODOIST_API_KEY"]
+        self.api_token = os.getenv("TODOIST_API_KEY")
         self.api = todoist.TodoistAPI(self.api_token)
         self.api.sync()
 

--- a/services/weatherAPI/test/test_service.py
+++ b/services/weatherAPI/test/test_service.py
@@ -34,11 +34,13 @@ class TestWeatherService(unittest.TestCase):
     def setUpClass(self):
         self.remote = None
         if "DONOTMOCK" in os.environ:
-            self.weather_adapter = WeatherAdapter.instance(WeatherMock.instance())
+            self.weather_adapter = WeatherAdapter.instance(
+                WeatherAdapterRemote.instance()
+            )
         else:
             print("Mocking remotes...")
             self.weather_adapter = WeatherAdapter.instance(
-                WeatherAdapterRemote.instance()
+                WeatherMock.instance()
             )
 
         self.weather_adapter.update(city="Stuttgart")

--- a/services/weatherAPI/weather_service.py
+++ b/services/weatherAPI/weather_service.py
@@ -29,7 +29,7 @@ class WeatherAdapterModule(ABC):
 @Singleton
 class WeatherAdapterRemote(WeatherAdapterModule):
     def __init__(self):
-        self.API_TOKEN = os.environ["OPENWEATHERMAP_API_KEY"]
+        self.API_TOKEN = os.getenv("OPENWEATHERMAP_API_KEY")
         self.base_url = "https://api.openweathermap.org/data/2.5"
         self.base_params = {"units": "metric", "appid": self.API_TOKEN}
 
@@ -108,7 +108,7 @@ class WeatherAdapter:
                 *coordinates
             )
         else:
-            raise Error("Provide either city or coordinates")
+            raise Exception("Provide either city or coordinates")
 
     def get_current_temperature(self):
         return float(self.weather["main"]["temp"])

--- a/services/yelp/yelp_service.py
+++ b/services/yelp/yelp_service.py
@@ -20,7 +20,7 @@ class YelpServiceModule(ABC):
 
 @Singleton
 class YelpServiceRemote(YelpServiceModule):
-    API_TOKEN = os.environ["YELP_API_KEY"]
+    API_TOKEN = os.getenv("YELP_API_KEY")
     headers = {
         "Authorization": "Bearer %s" % API_TOKEN,
     }


### PR DESCRIPTION
`getenv` is evaluated at dynamically during run time (when `DONOTMOCK`) is checked
whereas `os.environ['KEY']` is evaluated on `import`

`WeatherAdapterTest` somehow confused mocking with not mocking... gets our unittests down to 0.6 secs :)